### PR TITLE
Use Update SDK Authentication Flow

### DIFF
--- a/AsthmaHealth/ViewControllers/ACMSignUpViewController.m
+++ b/AsthmaHealth/ViewControllers/ACMSignUpViewController.m
@@ -43,20 +43,30 @@
         return;
     }
 
-    [CMHUser.currentUser signUpWithEmail:self.emailTextField.text
-                                          password:self.passwordTextField.text
-                                        andConsent:self.consentResults
-                                    withCompletion:^(NSError * _Nullable error) {
+    [CMHUser.currentUser signUpWithEmail:self.emailTextField.text password:self.passwordTextField.text andCompletion:^(NSError * _Nullable error) {
         if (nil != error) {
-            NSLog(@"Account Creation Failed: %@", error.localizedDescription);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [ACMAlerter displayAlertWithTitle:NSLocalizedString(@"Sign up Failed", nil)
+                                       andMessage:error.localizedDescription
+                                 inViewController:self];
+            });
             return;
         }
 
-        NSLog(@"Account Created Successfully");
+        [CMHUser.currentUser uploadUserConsent:self.consentResults forStudyWithDescriptor:@"ACMHealth" andCompletion:^(NSError * _Nullable consentError) {
+            if (nil != error) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [ACMAlerter displayAlertWithTitle:NSLocalizedString(@"Saving Consent Failed", nil)
+                                           andMessage:consentError.localizedDescription
+                                     inViewController:self];
+                });
+                return;
+            }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self.appDelegate loadMainPanel];
-        });
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.appDelegate loadMainPanel];
+            });
+        }];
     }];
 }
 

--- a/AsthmaHealth/ViewControllers/ACMSignUpViewController.m
+++ b/AsthmaHealth/ViewControllers/ACMSignUpViewController.m
@@ -54,7 +54,7 @@
         }
 
         [CMHUser.currentUser uploadUserConsent:self.consentResults forStudyWithDescriptor:@"ACMHealth" andCompletion:^(NSError * _Nullable consentError) {
-            if (nil != error) {
+            if (nil != consentError) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [ACMAlerter displayAlertWithTitle:NSLocalizedString(@"Saving Consent Failed", nil)
                                            andMessage:consentError.localizedDescription

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ platform :ios, '9.0'
 target 'AsthmaHealth' do
 pod 'TPKeyboardAvoiding', '~> 1.2'
 #pod 'CMHealth', :path => ENV['CMHEALTH_DEVELOPMENT_POD_PATH']
-pod 'CMHealth', :git => 'git@github.com:cloudmine/CMHealthSDK.git', :tag => '0.1.5'
+pod 'CMHealth', :git => 'git@github.com:cloudmine/CMHealthSDK.git', :tag => '0.1.6'
 end
 
 target 'AsthmaHealthTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - CloudMine (1.7.8):
     - AFNetworking (~> 2.5.4)
     - MAObjCRuntime (~> 0.0.1)
-  - CMHealth (0.1.5):
+  - CMHealth (0.1.6):
     - CloudMine (~> 1.7)
     - ResearchKit (~> 1.3)
   - MAObjCRuntime (0.0.1)
@@ -31,23 +31,23 @@ PODS:
   - TPKeyboardAvoiding (1.2.11)
 
 DEPENDENCIES:
-  - CMHealth (from `git@github.com:cloudmine/CMHealthSDK.git`, tag `0.1.5`)
+  - CMHealth (from `git@github.com:cloudmine/CMHealthSDK.git`, tag `0.1.6`)
   - TPKeyboardAvoiding (~> 1.2)
 
 EXTERNAL SOURCES:
   CMHealth:
     :git: git@github.com:cloudmine/CMHealthSDK.git
-    :tag: 0.1.5
+    :tag: 0.1.6
 
 CHECKOUT OPTIONS:
   CMHealth:
     :git: git@github.com:cloudmine/CMHealthSDK.git
-    :tag: 0.1.5
+    :tag: 0.1.6
 
 SPEC CHECKSUMS:
   AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
   CloudMine: 90ca98d8a4ff2b782ad8633706dd33adc2be560c
-  CMHealth: 7490c938a04e02e6913f0009a17fbbdfb4a62323
+  CMHealth: 26ed2a789a00cf96a9a322243dc81f976d6dc89b
   MAObjCRuntime: a6a1d95acbfa3784d66cb35bd42904e47943b488
   ResearchKit: 934a1efefed1a3a9150002a1e4b123d0c86c3f2e
   TPKeyboardAvoiding: e5ce146b313de063957bfa75a13f1e9b0ff18ab7


### PR DESCRIPTION
Signing up and uploading consent are now broken into two steps. Note that a consent upload failure still leaves the user logged in, but the SDK currently doesn't support fetching the consent to validate it's presence, so we do NOT handle this properly. Coming soon. 