### PR TITLE
Validate Consent for Logged in User

### DIFF
--- a/AsthmaHealth/ViewControllers/ACMMainPanelViewController.m
+++ b/AsthmaHealth/ViewControllers/ACMMainPanelViewController.m
@@ -21,6 +21,13 @@
     self.loadingOverlay = [ACMMainPanelViewController loadingIndicatorWithFrame:self.view.frame];
     self.tabBar.tintColor = [UIColor acmBlueColor];
 
+    [self validateConsentAndFetchData];
+}
+
+- (void)validateConsentAndFetchData
+{
+    [self showLoading:YES];
+
     [CMHUser.currentUser fetchUserConsentForStudyWithDescriptor:@"ACMHealth" andCompletion:^(CMHConsent * _Nullable consent, NSError * _Nullable error) {
         if (nil != error) {
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -45,7 +52,7 @@
 
             return;
         }
-
+        
         [self refreshData];
     }];
 }

--- a/AsthmaHealth/ViewControllers/ACMMainPanelViewController.m
+++ b/AsthmaHealth/ViewControllers/ACMMainPanelViewController.m
@@ -2,11 +2,14 @@
 #import <CMHealth/CMHealth.h>
 #import "NSDate+ACM.h"
 #import "UIColor+ACM.h"
+#import "ACMAlerter.h"
+#import "ACMAppDelegate.h"
 
 @interface ACMMainPanelViewController ()
 @property (nonatomic, nullable) UIView *loadingOverlay;
 @property (nonatomic, nullable, readwrite) ORKTaskResult *consentResult;
 @property (nonatomic, nullable, readwrite) NSArray <ORKTaskResult *> *surveyResults;
+@property (nonatomic, nullable, readonly) ACMAppDelegate *appDelegate;
 @end
 
 @implementation ACMMainPanelViewController
@@ -17,8 +20,34 @@
 
     self.loadingOverlay = [ACMMainPanelViewController loadingIndicatorWithFrame:self.view.frame];
     self.tabBar.tintColor = [UIColor acmBlueColor];
-    
-    [self refreshData];
+
+    [CMHUser.currentUser fetchUserConsentForStudyWithDescriptor:@"ACMHealth" andCompletion:^(CMHConsent * _Nullable consent, NSError * _Nullable error) {
+        if (nil != error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [ACMAlerter displayAlertWithTitle:NSLocalizedString(@"Failled to Verify Consent", nil)
+                                       andMessage:[NSString localizedStringWithFormat:@"Please try logging in or completing particpant consent; %@", error.localizedDescription]
+                                 inViewController:self];
+
+                [self.appDelegate loadOnboarding];
+            });
+
+            return;
+        }
+
+        if (nil == consent) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [ACMAlerter displayAlertWithTitle:NSLocalizedString(@"Consent for study not found", nil)
+                                       andMessage:NSLocalizedString(@"Please complete participant consent before proceeding", nil)
+                                 inViewController:self];
+
+                [self.appDelegate loadOnboarding];
+            });
+
+            return;
+        }
+
+        [self refreshData];
+    }];
 }
 
 - (void)refreshData
@@ -76,6 +105,15 @@
     }
 
     return surveyResultsOnDay.count;
+}
+
+#pragma mark Getters-Setters
+- (ACMAppDelegate *)appDelegate
+{
+    ACMAppDelegate *appDelegate = [UIApplication sharedApplication].delegate;
+    NSAssert([appDelegate isKindOfClass:[ACMAppDelegate class]], @"App Delegate is unexpected type: %@", [appDelegate class]);
+
+    return appDelegate;
 }
 
 #pragma mark Private

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ platform :ios, '9.0'
 target 'AsthmaHealth' do
 pod 'TPKeyboardAvoiding', '~> 1.2'
 #pod 'CMHealth', :path => ENV['CMHEALTH_DEVELOPMENT_POD_PATH']
-pod 'CMHealth', :git => 'git@github.com:cloudmine/CMHealthSDK.git', :tag => '0.1.6'
+pod 'CMHealth', :git => 'git@github.com:cloudmine/CMHealthSDK.git', :tag => '0.1.7'
 end
 
 target 'AsthmaHealthTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - CloudMine (1.7.8):
     - AFNetworking (~> 2.5.4)
     - MAObjCRuntime (~> 0.0.1)
-  - CMHealth (0.1.6):
+  - CMHealth (0.1.7):
     - CloudMine (~> 1.7)
     - ResearchKit (~> 1.3)
   - MAObjCRuntime (0.0.1)
@@ -31,23 +31,23 @@ PODS:
   - TPKeyboardAvoiding (1.2.11)
 
 DEPENDENCIES:
-  - CMHealth (from `git@github.com:cloudmine/CMHealthSDK.git`, tag `0.1.6`)
+  - CMHealth (from `git@github.com:cloudmine/CMHealthSDK.git`, tag `0.1.7`)
   - TPKeyboardAvoiding (~> 1.2)
 
 EXTERNAL SOURCES:
   CMHealth:
     :git: git@github.com:cloudmine/CMHealthSDK.git
-    :tag: 0.1.6
+    :tag: 0.1.7
 
 CHECKOUT OPTIONS:
   CMHealth:
     :git: git@github.com:cloudmine/CMHealthSDK.git
-    :tag: 0.1.6
+    :tag: 0.1.7
 
 SPEC CHECKSUMS:
   AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
   CloudMine: 90ca98d8a4ff2b782ad8633706dd33adc2be560c
-  CMHealth: 26ed2a789a00cf96a9a322243dc81f976d6dc89b
+  CMHealth: 225d628b5f421e4b3a3302ce352165e57978365b
   MAObjCRuntime: a6a1d95acbfa3784d66cb35bd42904e47943b488
   ResearchKit: 934a1efefed1a3a9150002a1e4b123d0c86c3f2e
   TPKeyboardAvoiding: e5ce146b313de063957bfa75a13f1e9b0ff18ab7


### PR DESCRIPTION
Before allowing a logged in  user to proceed with surveys, validate that user has a consent on file, using the methods implemented in SDK 0.1.7